### PR TITLE
Fixed Issue #36: GoDaddy API self signed cert

### DIFF
--- a/classes/DomainMOD/GoDaddy.php
+++ b/classes/DomainMOD/GoDaddy.php
@@ -50,6 +50,7 @@ class GoDaddy
         curl_setopt($handle, CURLOPT_HTTPHEADER, array(
             'Authorization: sso-key ' . $api_key . ':' . $api_secret,
             'Accept: application/json'));
+        curl_setopt($handle, CURLOPT_SSL_VERIFYPEER, 0);
         curl_setopt($handle, CURLOPT_RETURNTRANSFER, 1);
         $result = curl_exec($handle);
         curl_close($handle);
@@ -72,12 +73,12 @@ class GoDaddy
 
                 $domain_list[] = $domain['domain'];
                 $domain_count++;
-
+                
             }
 
         } else {
 
-            $log_message = 'Unable to get domain list';
+            $log_message = 'Unable to get domain list: '.$api_results;
             $log_extra = array('API Key' => $this->format->obfusc($api_key), 'API Secret' => $this->format->obfusc($api_secret));
             $this->log->error($log_message, $log_extra);
 


### PR DESCRIPTION
For issue #37. This should fix the problem with not being able to curl godaddy's api because of it's self-signed certificate.