### PR TITLE
Replace Yahoo Finance API with Fixer.io API

### DIFF
--- a/classes/DomainMOD/Conversion.php
+++ b/classes/DomainMOD/Conversion.php
@@ -49,7 +49,7 @@ class Conversion
 
         foreach ($result as $row) {
 
-            $conversion_rate = $this->getConversionRate($row->currency, $default_currency);
+			$conversion_rate = $row->currency == $default_currency ? 1 : $this->getConversionRate($row->currency, $default_currency);
 
             $bind_currency_id = $row->id;
             $stmt->execute();
@@ -113,15 +113,15 @@ class Conversion
 
     public function getConversionRate($from_currency, $to_currency)
     {
-        $full_url = "http://download.finance.yahoo.com/d/quotes.csv?e=.csv&f=sl1d1t1&s=" . $from_currency . $to_currency . "=X";
+		$full_url = "https://api.fixer.io/latest?base=" . $from_currency . '&symbols=' . $to_currency;
         $handle = curl_init($full_url);
         curl_setopt($handle, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($handle, CURLOPT_SSL_VERIFYHOST, false);
         curl_setopt($handle, CURLOPT_SSL_VERIFYPEER, false);
         $result = curl_exec($handle);
         curl_close($handle);
-        $api_call_split = explode(",", $result);
-        $conversion_rate = $api_call_split[1];
+		$json_result = json_decode($result);
+		$conversion_rate = $json_result->rates->$to_currency;
 
         if ($conversion_rate != '' && $conversion_rate != 'N/A' && $conversion_rate != 'n/a') {
 

--- a/classes/DomainMOD/Conversion.php
+++ b/classes/DomainMOD/Conversion.php
@@ -49,7 +49,7 @@ class Conversion
 
         foreach ($result as $row) {
 
-			$conversion_rate = $row->currency == $default_currency ? 1 : $this->getConversionRate($row->currency, $default_currency);
+            $conversion_rate = $row->currency == $default_currency ? 1 : $this->getConversionRate($row->currency, $default_currency);
 
             $bind_currency_id = $row->id;
             $stmt->execute();
@@ -113,15 +113,15 @@ class Conversion
 
     public function getConversionRate($from_currency, $to_currency)
     {
-		$full_url = "https://api.fixer.io/latest?base=" . $from_currency . '&symbols=' . $to_currency;
+        $full_url = 'https://api.fixer.io/latest?base=' . $from_currency . '&symbols=' . $to_currency;
         $handle = curl_init($full_url);
         curl_setopt($handle, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($handle, CURLOPT_SSL_VERIFYHOST, false);
         curl_setopt($handle, CURLOPT_SSL_VERIFYPEER, false);
         $result = curl_exec($handle);
         curl_close($handle);
-		$json_result = json_decode($result);
-		$conversion_rate = $json_result->rates->$to_currency;
+        $json_result = json_decode($result);
+        $conversion_rate = $json_result->rates->$to_currency;
 
         if ($conversion_rate != '' && $conversion_rate != 'N/A' && $conversion_rate != 'n/a') {
 
@@ -129,7 +129,7 @@ class Conversion
 
         } else {
 
-            $log_message = 'Unable to retrieve Yahoo! Finance currency conversion';
+            $log_message = 'Unable to retrieve Fixer.io currency conversion';
             $log_extra = array('From Currency' => $from_currency, 'To Currency' => $to_currency,
                                'Conversion Rate Result' => $conversion_rate);
             $this->log->error($log_message, $log_extra);


### PR DESCRIPTION
When using the Yahoo API as used in the DomainMOD\Conversion class, I get the following error:

> It has come to our attention that this service is being used in violation of the Yahoo Terms of Service. As such, the service is being discontinued. For all future markets and equities data research, please refer to finance.yahoo.com.

So I've updated the code to only retrieve currency conversion rate if different currencies are used and to use the [fixer.io](http://fixer.io) API.