### PR TITLE
Add support for MySQL servers that require encrypted connections.

### DIFF
--- a/_includes/config.SAMPLE.inc.php
+++ b/_includes/config.SAMPLE.inc.php
@@ -28,3 +28,7 @@ $dbhostname = 'localhost';
 $dbname = 'db_name';
 $dbusername = 'db_username';
 $dbpassword = 'dbPassword123';
+$dbsslca = '/etc/ssl/certs/self-signed-cert.pem';
+$dbsslcapath = '/etc/ssl/certs';
+// set to false when the server uses a self-signed cert
+$dbsslverifycert = true;

--- a/_includes/software.inc.php
+++ b/_includes/software.inc.php
@@ -27,3 +27,6 @@ define('DB_HOSTNAME', $dbhostname);
 define('DB_NAME', $dbname);
 define('DB_USERNAME', $dbusername);
 define('DB_PASSWORD', $dbpassword);
+define('DB_SSL_CA', $dbsslca);
+define('DB_SSL_CAPATH', $dbsslcapath);
+define('DB_SSL_VERIFY_CERT', $dbsslverifycert);

--- a/classes/DomainMOD/Database.php
+++ b/classes/DomainMOD/Database.php
@@ -30,8 +30,19 @@ class Database
 
     private function __construct()
     {
-        $this->cnxx = new \PDO("mysql:host=" . DB_HOSTNAME . ";dbname=" . DB_NAME . ";charset=utf8", DB_USERNAME, DB_PASSWORD,
-                               array(\PDO::MYSQL_ATTR_INIT_COMMAND => 'SET sql_mode="NO_ENGINE_SUBSTITUTION"'));
+        // SSL cannot be enabled with PDO::setAttribute because the connection already exists
+        $options = array(
+            \PDO::MYSQL_ATTR_INIT_COMMAND => 'SET sql_mode="NO_ENGINE_SUBSTITUTION"',
+            \PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => DB_SSL_VERIFY_CERT
+        );
+        if (DB_SSL_CA !== false) {
+            $options[\PDO::MYSQL_ATTR_SSL_CA] = DB_SSL_CA;
+        }
+        if (DB_SSL_CAPATH !== false) {
+            $options[\PDO::MYSQL_ATTR_SSL_CAPATH] = DB_SSL_CAPATH;
+        }
+        $dsn = "mysql:host=" . DB_HOSTNAME . ";dbname=" . DB_NAME . ";charset=utf8";
+        $this->cnxx = new \PDO($dsn, DB_USERNAME, DB_PASSWORD, $options);
 
         $this->cnxx->exec("SET NAMES utf8");
         $this->cnxx->setAttribute(\PDO::ATTR_EMULATE_PREPARES, false);


### PR DESCRIPTION
This PR allows connecting to MySQL servers that require encrypted connections (option require-secure-transport=ON).

To use:
- Set $dbsslca to the full path of a file that contains list of trusted SSL Certificate Authorities.
- Set $dbsslcapath to a directory that contains trusted SSL Certificate Authority certificate files.
- Set $dbsslverifycert to false to disable verification of the server SSL certificate.
