### PR TITLE
Migrate to new version of fawazahmed0's currency API

### DIFF
--- a/vendor/chetcuti/gjclasses/src/GJClasses/Currency.php
+++ b/vendor/chetcuti/gjclasses/src/GJClasses/Currency.php
@@ -46,12 +46,12 @@ class Currency
             $from_currency = strtolower($from_currency);
             $to_currency = strtolower($to_currency);
 
-            $full_url = 'https://cdn.jsdelivr.net/gh/fawazahmed0/currency-api@1/latest/currencies/' . $from_currency . '/' . $to_currency . '.json';
+            $full_url = 'https://cdn.jsdelivr.net/npm/@fawazahmed0/currency-api@latest/v1/currencies/' . $from_currency . '.json';
             $remote = new Remote();
             $result = $remote->getFileContents($full_url);
             if ($result === false) return false;
             $json_result = json_decode($result, true);
-            $conversion_rate = $json_result[$to_currency];
+            $conversion_rate = $json_result[$from_currency][$to_currency];
 
         } elseif ($this->source === 'fixer') {
 


### PR DESCRIPTION
Due to fawazahmed0/exchange-api#89, the old API is down and doesn't work anymore. This PR migrates it to use the newer API as documented in https://github.com/fawazahmed0/exchange-api/blob/main/MIGRATION.md.