### PR TITLE
Fix invalid 6-field CRON expression saved to database

### DIFF
--- a/admin/scheduler/update.php
+++ b/admin/scheduler/update.php
@@ -47,7 +47,7 @@ if ($a == 'u') {
     $new_time = date('Y-m-d H:i:s', mktime($new_hour, '00', '00', date("m"), date("d"), date("Y")));
     $new_time_utc = $time->toUtcTimezone($new_time);
     $hour = date("G", strtotime($new_time_utc));
-    $full_expression = '0 ' . $hour . ' * * * *';
+    $full_expression = '0 ' . $hour . ' * * *';
 
     $stmt = $pdo->prepare("
         UPDATE scheduler


### PR DESCRIPTION
The current code in admin/scheduler/update.php generates and stores a CRON expression with 6 fields (e.g., 0 16 * * * *), which is incompatible with the dragonmantank/cron-expression library that expects a standard 5-field format.

This results in the following fatal error:

PHP Fatal error:  Uncaught InvalidArgumentException: 6 is not a valid position in FieldFactory.php:48 Steps to Reproduce
Trigger a scheduler update (action a=u or a=e)

The expression 0 16 * * * * is written to the scheduler table

When parsing it with CronExpression, an exception is thrown due to 6 fields

Suggested Fix
Change CRON expression generation to use 5 fields instead:

$full_expression = '0 ' . $hour . ' * * *';
Optionally validate the expression before saving:

$cron = new Cron\CronExpression($full_expression);